### PR TITLE
Match autobidsportal version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 
 [tool.poetry]
 name = "autobids-globus"
-version = "0.1.0"
+version = "2.1.0"
 description = ""
 authors = ["Tristan Kuehn <tkuehn@uwo.ca>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Autobids-Globus"
-version = "0.0.1"
+version = "2.1.0"
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
This is minor change, but also realize its not typical. Looking to match the version of this with autobidsportal, primarily for documentation purposes, but also to keep them all on the same version. For now versioning of this will need to be manually done, but will look into pulling tags from the remote autobidsportal for release as part of a CI task.