### PR TITLE
Create version update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,5 +31,29 @@ jobs:
 
       - name: Create versioned tag
         run: |
-          git tag v${{ github.event.client_payload.version }} -a -m "Release v${{ github.event.client_payload.version }}." main
+          git tag v${{ github.event.client_payload.version }} -a -m "Tag v${{ github.event.client_payload.version }}." main
           git push --tags
+
+  dispatch:
+    needs: [update_version]
+    name: Create dispatch event for docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        run: |
+          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+          echo "LATEST_TAG=$(echo ${LATEST_TAG:1})" >> $GITHUB_ENV
+
+      - name: Create dispatch event for autobids-docs
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.BP_PAT_TOKEN }}
+          repository: khanlab/autobids-docs
+          event-type: autobidsportal_release
+          client-payload: '{"version": "${{ env.LATEST_TAG }}"}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,35 @@
+# Update for documentation purposes (triggered by autobidsportal release)
+name: Update and create tagged version
+
+on:
+  repository_dispatch: # Trigger from a remote repository event
+    types: [autobidsportal_release]
+
+jobs:
+  update_version:
+    name: Update version in autobids-docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Update pyproject.toml version
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          include: pyproject.toml
+          find: version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"
+          replace: version = "${{ github.event.client_payload.version }}"
+
+      # Switch to protected commit when BP enabled
+      - name: Commit & push changes
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff-index --quiet HEAD || git commit -m "[BOT] Bump to version ${{ github.event.client_payload.version }}" -a
+          git push
+
+      - name: Create versioned tag
+        run: |
+          git tag v${{ github.event.client_payload.version }} -a -m "Release v${{ github.event.client_payload.version }}." main
+          git push --tags


### PR DESCRIPTION
PR adds a workflow that:

1. Triggers when the `autobidsportal` creates a new release (or is user triggered). This updates the current version in this repository to match that of the `autobidsportal` release version and creates a new tag. 
2. Create a dispatch event to trigger updating of the `autobids-docs`.